### PR TITLE
Bump GitHub Action versions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-dependency-glob: uv.lock
@@ -49,11 +49,11 @@ jobs:
 
     - name: Setup Pages
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@v6
 
     - name: Upload artifact
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: ./site
 
@@ -68,5 +68,5 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,16 +9,16 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-dependency-glob: uv.lock
     - name: Sync dependencies
       run: uv sync --locked --no-default-groups --group dev
     - name: Cache pre-commit hook environments
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ jobs:
       contents: read
     environment: pypi
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-dependency-glob: uv.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -27,7 +27,7 @@ jobs:
       - name: Testing with coverage
         run: uv run pytest tests --cov=interpolatepy --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
## Summary

Bumps every GitHub Action used in our workflows to a major that runs on Node.js 24, fixing the deprecation warnings GitHub posts on every run today (Node 20 actions are auto-forced to Node 24 on **2026-06-02** and removed entirely on **2026-09-16**).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `astral-sh/setup-uv` | `@v6` | `@v8.1.0` (pinned — no more major tags, see note) |
| `actions/cache` | `@v4` | `@v5` |
| `codecov/codecov-action` | `@v5` | `@v6` |
| `actions/configure-pages` | `@v4` | `@v6` |
| `actions/upload-pages-artifact` | `@v3` | `@v5` |
| `actions/deploy-pages` | `@v4` | `@v5` |

`pypa/gh-action-pypi-publish@release/v1` was already on the floating release tag and is unchanged.

## Notable breaking-change checks

- **`astral-sh/setup-uv@v8`** stopped publishing major/minor floating tags as a supply-chain hardening measure (post tj-actions incident). Pinned to the immutable `v8.1.0` tag. Consider moving to a SHA pin in a follow-up.
- **`actions/upload-pages-artifact@v4`** stopped including dotfiles in the artifact. Our `mkdocs build` site/ output has none, so safe.
- **`actions/configure-pages@v5`** dropped Next.js < 13.3.0 support — irrelevant (no `static_site_generator: next` input here).
- **`actions/cache@v5`** + **`actions/checkout@v5+`** require runner ≥ 2.327.1; GitHub-hosted runners are well past this.
- **`codecov/codecov-action@v6`** is purely the Node 24 bump.

## Test plan

- [x] `actionlint` clean across all 4 workflows.
- [ ] CI passes on this PR (real-runner validation — the only way to verify the action version bumps actually work).
- [ ] No new deprecation annotations on the run.